### PR TITLE
Node Bump To Fix Deprecation Warnings

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -11,7 +11,7 @@ inputs:
     default: base64
 
 runs:
-  using: node12
+  using: node16
   main: dist/index.js
   post: dist/index.js
 


### PR DESCRIPTION
This was tested with the fork to resolve the Node12 Deprecation warnings on the Github Action workflows.